### PR TITLE
Fix meta rauc reference

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = git://git.yoctoproject.org/meta-raspberrypi
 [submodule "meta-rauc"]
 	path = meta-rauc
-	url = https://github.com/rauc/rauc
+	url = https://github.com/rauc/meta-rauc.git


### PR DESCRIPTION
meta-rauc repository branch changed to scarthgap